### PR TITLE
Fix RequestException::withoutResponseError

### DIFF
--- a/src/Exceptions/RequestException.php
+++ b/src/Exceptions/RequestException.php
@@ -41,7 +41,7 @@ class RequestException extends \Exception
 
     public static function withoutResponseError($message, Throwable $previous, int $code = 0): self
     {
-        $self = new self($message, $previous, $code);
+        $self = new self($message, $code, $previous);
         $self->errorCode = 500;
 
         return $self;

--- a/tests/RequestExceptionTest.php
+++ b/tests/RequestExceptionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Napp\Salesforce\Tests;
+
+class RequestExceptionTest extends TestCase {
+
+    /** @test */
+    public function without_response_error()
+    {
+        $message = 'abc123';
+        $code = 1;
+        $previous = new \Exception('hello');
+        $e = \Napp\Salesforce\Exceptions\RequestException::withoutResponseError(
+            $message,
+            $previous,
+            $code
+        );
+
+        $this->assertInstanceOf(\Napp\Salesforce\Exceptions\RequestException::class, $e);
+        $this->assertSame($message, $e->getMessage());
+        $this->assertSame($code, $e->getCode());
+        $this->assertSame($previous, $e->getPrevious());
+    }
+}


### PR DESCRIPTION
An error has occurred due to `Wrong parameters` by RequestException::withoutResponseError.

input
```
RequestException::withoutResponseError('abc123', new \Exception('hello'), 1);
```

output
```
PHP Error:  Wrong parameters for Napp/Salesforce/Exceptions/RequestException([string $message [, long $code [, Throwable $previous = NULL]]]) 
```