### PR TITLE
Fix AccessToken::refresh by parsing milli seconds timestamp.

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -83,7 +83,7 @@ class AccessToken
      */
     public function refresh(array $response): self
     {
-        $this->dateIssued = Carbon::createFromTimestamp($response['issued_at']);
+        $this->dateIssued = Carbon::createFromTimestampMs($response['issued_at']);
 
         $this->dateExpires = $this->dateIssued->copy()->addHour()->subMinutes(5);
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -153,7 +153,7 @@ class ClientTest extends TestCase
     {
         $sfClient = new Client($this->getClientConfigMock(), $this->mockGuzzleClient([
             new Response(200, [], json_encode([
-                'issued_at' => time(),
+                'issued_at' => (string)time() . '000',
                 'id' => 'some-fake-id',
                 'access_token' => 'some-fake-token',
                 'instance_url' => 'some-instance',


### PR DESCRIPTION
https://developer.salesforce.com/docs/atlas.en-us.218.0.api_rest.meta/api_rest/intro_understanding_web_server_oauth_flow.htm

```
issued_at	When the signature was created, represented as the number of seconds since the Unix epoch (00:00:00 UTC on 1 January 1970).
```

But, sample timestamp `"issued_at":"1278448101416",` contains milli seconds.
This timestamp is 2010-07-07 05:23:21.416
